### PR TITLE
Fix an issue with line separator for "checksum.txt" on linux system

### DIFF
--- a/src/cpp/game/launcher/PatchCreator.java
+++ b/src/cpp/game/launcher/PatchCreator.java
@@ -227,7 +227,7 @@ public class PatchCreator
         output += "\t" + sha256Hash;
 
         // Finalize the line in the checksum file
-        outputBw.write(output + "\r\n");
+        outputBw.write(output + "\n");
     }
 
     // Create base64 encoded signature using SHA256/RSA.


### PR DESCRIPTION
When you upload "checksum.txt" file to linux system using FileZilla ftp client, all "\r\n" will be auto converted to "\n", which cause the hash of the file were changed and fail on RSA verifiy step.